### PR TITLE
Check available values in enums

### DIFF
--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -4,6 +4,7 @@ namespace Consistence\Enum;
 
 use Consistence\Reflection\ClassReflection;
 use Consistence\Type\ArrayType\ArrayType;
+use Consistence\Type\Type;
 
 use ReflectionClass;
 
@@ -34,12 +35,22 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	 */
 	public static function get($value)
 	{
-		$index = sprintf('%s::$%s', get_called_class(), $value);
+		$index = sprintf('%s::%s', get_called_class(), self::getValueIndex($value));
 		if (!isset(self::$instances[$index])) {
 			self::$instances[$index] = new static($value);
 		}
 
 		return self::$instances[$index];
+	}
+
+	/**
+	 * @param mixed $value
+	 * @return string
+	 */
+	private static function getValueIndex($value)
+	{
+		$type = Type::getType($value);
+		return $value . sprintf('[%s]', $type);
 	}
 
 	/**

--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -60,7 +60,9 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	{
 		$index = get_called_class();
 		if (!isset(self::$availableValues[$index])) {
-			self::$availableValues[$index] = self::getEnumConstants();
+			$availableValues = self::getEnumConstants();
+			static::checkAvailableValues($availableValues);
+			self::$availableValues[$index] = $availableValues;
 		}
 
 		return self::$availableValues[$index];
@@ -76,6 +78,22 @@ abstract class Enum extends \Consistence\ObjectPrototype
 		ArrayType::removeKeys($declaredConstants, static::getIgnoredConstantNames());
 
 		return $declaredConstants;
+	}
+
+	/**
+	 * @param mixed[] $availableValues
+	 */
+	protected static function checkAvailableValues(array $availableValues)
+	{
+		$index = [];
+		foreach ($availableValues as $value) {
+			Type::checkType($value, 'integer|string|float|boolean|null');
+			$key = self::getValueIndex($value);
+			if (isset($index[$key])) {
+				throw new \Consistence\Enum\DuplicateValueSpecifiedException($value, static::class);
+			}
+			$index[$key] = true;
+		}
 	}
 
 	/**

--- a/src/Enum/MultiEnum.php
+++ b/src/Enum/MultiEnum.php
@@ -5,6 +5,7 @@ namespace Consistence\Enum;
 use ArrayIterator;
 use Closure;
 
+use Consistence\Math\Math;
 use Consistence\Type\ArrayType\ArrayType;
 use Consistence\Type\Type;
 
@@ -30,12 +31,27 @@ abstract class MultiEnum extends \Consistence\Enum\Enum implements \IteratorAggr
 		$index = get_called_class();
 		if (!isset(self::$availableValues[$index])) {
 			$singleEnumClass = static::getSingleEnumClass();
-			self::$availableValues[$index] = ($singleEnumClass !== null)
+			$availableValues = ($singleEnumClass !== null)
 				? self::getSingleEnumMappedAvailableValues($singleEnumClass)
 				: parent::getAvailableValues();
+			static::checkAvailableValues($availableValues);
+			self::$availableValues[$index] = $availableValues;
 		}
 
 		return self::$availableValues[$index];
+	}
+
+	/**
+	 * @param integer[] $availableValues
+	 */
+	protected static function checkAvailableValues(array $availableValues)
+	{
+		parent::checkAvailableValues($availableValues);
+		foreach ($availableValues as $value) {
+			if (!Math::isPowerOfTwo($value)) {
+				throw new \Consistence\Enum\MultiEnumValueIsNotPowerOfTwoException($value, static::class);
+			}
+		}
 	}
 
 	/**

--- a/src/Enum/exceptions/DuplicateValueSpecifiedException.php
+++ b/src/Enum/exceptions/DuplicateValueSpecifiedException.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Consistence\Enum;
+
+use Consistence\Type\Type;
+
+class DuplicateValueSpecifiedException extends \Consistence\PhpException implements \Consistence\Enum\Exception
+{
+
+	/** @var mixed */
+	private $value;
+
+	/** @var string */
+	private $class;
+
+	/**
+	 * @param mixed $value
+	 * @param string $class
+	 * @param \Exception|null $previous
+	 */
+	public function __construct($value, $class, \Exception $previous = null)
+	{
+		parent::__construct(sprintf(
+			'Value %s [%s] is specified in %s\'s available values multiple times',
+			$value,
+			Type::getType($value),
+			$class
+		), $previous);
+		$this->value = $value;
+		$this->class = $class;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getClass()
+	{
+		return $this->class;
+	}
+
+}

--- a/src/Enum/exceptions/MultiEnumValueIsNotPowerOfTwoException.php
+++ b/src/Enum/exceptions/MultiEnumValueIsNotPowerOfTwoException.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Consistence\Enum;
+
+class MultiEnumValueIsNotPowerOfTwoException extends \Consistence\PhpException implements \Consistence\Enum\Exception
+{
+
+	/** @var integer */
+	private $value;
+
+	/** @var string */
+	private $class;
+
+	/**
+	 * @param integer $value
+	 * @param string $class
+	 * @param \Exception|null $previous
+	 */
+	public function __construct($value, $class, \Exception $previous = null)
+	{
+		parent::__construct(sprintf(
+			'Value %s in %s is not a power of two, which is needed for MultiEnum to work as expected',
+			$value,
+			$class
+		), $previous);
+		$this->value = $value;
+		$this->class = $class;
+	}
+
+	/**
+	 * @return integer
+	 */
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getClass()
+	{
+		return $this->class;
+	}
+
+}

--- a/src/Math/Math.php
+++ b/src/Math/Math.php
@@ -32,4 +32,19 @@ class Math extends \Consistence\ObjectPrototype
 		return $result;
 	}
 
+	/**
+	 * @param integer $value
+	 * @return boolean
+	 */
+	public static function isPowerOfTwo($value)
+	{
+		Type::checkType($value, 'integer');
+
+		if ($value < 1) {
+			return false;
+		}
+
+		return ($value & ($value - 1)) === 0;
+	}
+
 }

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -2,6 +2,8 @@
 
 namespace Consistence\Enum;
 
+use Consistence\Type\ArrayType\ArrayType;
+
 class EnumTest extends \Consistence\TestCase
 {
 
@@ -153,6 +155,28 @@ class EnumTest extends \Consistence\TestCase
 				'PUBLISHED' => StatusEnum::PUBLISHED,
 			], $e->getAvailableValues());
 		}
+	}
+
+	/**
+	 * @return mixed[][]
+	 */
+	public function typesProvider()
+	{
+		return ArrayType::mapValuesByCallback(TypeEnum::getAvailableValues(), function ($value) {
+			return [$value];
+		});
+	}
+
+	/**
+	 * @dataProvider typesProvider
+	 *
+	 * @param mixed $value
+	 */
+	public function testTypes($value)
+	{
+		$enum = TypeEnum::get($value);
+		$this->assertInstanceOf(TypeEnum::class, $enum);
+		$this->assertSame($enum->getValue(), $value);
 	}
 
 }

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -179,4 +179,15 @@ class EnumTest extends \Consistence\TestCase
 		$this->assertSame($enum->getValue(), $value);
 	}
 
+	public function testDuplicateSpecifiedValues()
+	{
+		try {
+			DuplicateValuesEnum::get(DuplicateValuesEnum::BAZ);
+			$this->fail();
+		} catch (\Consistence\Enum\DuplicateValueSpecifiedException $e) {
+			$this->assertSame(DuplicateValuesEnum::FOO, $e->getValue());
+			$this->assertSame(DuplicateValuesEnum::class, $e->getClass());
+		}
+	}
+
 }

--- a/tests/Enum/MultiEnumTest.php
+++ b/tests/Enum/MultiEnumTest.php
@@ -608,4 +608,15 @@ class MultiEnumTest extends \Consistence\TestCase
 		$this->assertSame(RolesEnum::get(RoleEnum::USER), $newRoles);
 	}
 
+	public function testDuplicateSpecifiedValues()
+	{
+		try {
+			MultiEnumWithValuesNotPowerOfTwo::get(MultiEnumWithValuesNotPowerOfTwo::FOO);
+			$this->fail();
+		} catch (\Consistence\Enum\MultiEnumValueIsNotPowerOfTwoException $e) {
+			$this->assertSame(MultiEnumWithValuesNotPowerOfTwo::BAZ, $e->getValue());
+			$this->assertSame(MultiEnumWithValuesNotPowerOfTwo::class, $e->getClass());
+		}
+	}
+
 }

--- a/tests/Enum/data/DuplicateValuesEnum.php
+++ b/tests/Enum/data/DuplicateValuesEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Consistence\Enum;
+
+class DuplicateValuesEnum extends \Consistence\Enum\Enum
+{
+
+	const FOO = 'foo';
+	const BAR = 'foo';
+	const BAZ = 'baz';
+
+}

--- a/tests/Enum/data/MultiEnumWithValuesNotPowerOfTwo.php
+++ b/tests/Enum/data/MultiEnumWithValuesNotPowerOfTwo.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Consistence\Enum;
+
+class MultiEnumWithValuesNotPowerOfTwo extends \Consistence\Enum\MultiEnum
+{
+
+	const FOO = 1;
+	const BAR = 2;
+	const BAZ = 3;
+
+}

--- a/tests/Enum/data/TypeEnum.php
+++ b/tests/Enum/data/TypeEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Consistence\Enum;
+
+class TypeEnum extends \Consistence\Enum\Enum
+{
+
+	const INTEGER = 1;
+	const STRING = '1';
+	const FLOAT = 1.0;
+	const BOOLEAN = true;
+	const NULL = null;
+
+}

--- a/tests/Math/MathTest.php
+++ b/tests/Math/MathTest.php
@@ -39,4 +39,36 @@ class MathTest extends \Consistence\TestCase
 		}
 	}
 
+	/**
+	 * @return mixed[][]
+	 */
+	public function powersOfTwoProvider()
+	{
+		return [
+			[-2, false],
+			[-1, false],
+			[0, false],
+			[1, true],
+			[2, true],
+			[3, false],
+			[4, true],
+			[6, false],
+			[8, true],
+			[10, false],
+			[16, true],
+			[32, true],
+		];
+	}
+
+	/**
+	 * @dataProvider powersOfTwoProvider
+	 *
+	 * @param integer $value
+	 * @param boolean $result
+	 */
+	public function testIsPowerOfTwo($value, $result)
+	{
+		$this->assertSame(Math::isPowerOfTwo($value), $result);
+	}
+
 }


### PR DESCRIPTION
Checking of common mistakes when defining Enums:

* for single + MultiEnums check valid types
* for single + MultiEnums check if the values are not duplicate
* for MultiEnums check that values are powers of two
* possibility to override and define custom additional checks
* is checked only once per enum class

cc @OndrejMirtes