### PR TITLE
Microseconds support

### DIFF
--- a/src/Time/TimeFormat.php
+++ b/src/Time/TimeFormat.php
@@ -19,6 +19,7 @@ class TimeFormat extends \Consistence\ObjectPrototype
 	const ATOM = DATE_ATOM;
 	const COOKIE = DATE_COOKIE;
 	const ISO8601 = DATE_ISO8601;
+	const ISO8601_WITH_MICROSECONDS = 'Y-m-d\TH:i:s.uO';
 	const ISO8601_WITH_MICROSECONDS_WITHOUT_TIMEZONE = 'Y-m-d\TH:i:s.u';
 	const ISO8601_TIMEZONE_WITH_COLON = DATE_RFC3339;
 	const ISO8601_WITHOUT_TIMEZONE = 'Y-m-d\TH:i:s';
@@ -128,7 +129,7 @@ class TimeFormat extends \Consistence\ObjectPrototype
 	 * This is achieved by parsing the date and then filling missing time parts,
 	 * because if some parts are missing then the current time according to the system
 	 * is used to fill these, which is unpredictable. The chosen "neutral" date
-	 * is 2016-07-17\T12:30:30Z which is a leap year and a date where no daylight savings time
+	 * is 2016-07-17\T12:30:30.5Z which is a leap year and a date where no daylight savings time
 	 * shifts occurred or are planned.
 	 *
 	 * This should ensure, that only time parts that are specified in the format are taken into
@@ -168,17 +169,20 @@ class TimeFormat extends \Consistence\ObjectPrototype
 				$timezone = 'UTC';
 		}
 		$completeTime = sprintf(
-			'%d-%02d-%02d %02d:%02d:%02d %s',
+			'%d-%02d-%02d %02d:%02d:%09.6f %s',
 			$parsedTime['year'] !== false ? $parsedTime['year'] : 2016, // leap year
 			$parsedTime['month'] !== false ? $parsedTime['month'] : 7, // no time shifts occurred on 7-17
 			$parsedTime['day'] !== false ? $parsedTime['day'] : 17,
 			$parsedTime['hour'] !== false ? $parsedTime['hour'] : 12,
 			$parsedTime['minute'] !== false ? $parsedTime['minute'] : 30,
-			$parsedTime['second'] !== false ? $parsedTime['second'] : 30,
+			(
+				($parsedTime['second'] !== false ? $parsedTime['second'] : 30)
+				+ ($parsedTime['fraction'] !== false ? $parsedTime['fraction'] : 0.5)
+			),
 			$timezone
 		);
 		// timezone is parsed as abbreviation, but that does not matter, while parsing it recognizes all formats
-		$dateTime = DateTime::createFromFormat('Y-m-d H:i:s T', $completeTime);
+		$dateTime = DateTime::createFromFormat('Y-m-d H:i:s.u T', $completeTime);
 		if (
 			($parsedTime['year'] !== false && (int) $parsedTime['year'] !== (int) $dateTime->format(self::YEAR))
 			|| ($parsedTime['month'] !== false && (int) $parsedTime['month'] !== (int) $dateTime->format(self::MONTH_OF_YEAR))
@@ -186,6 +190,7 @@ class TimeFormat extends \Consistence\ObjectPrototype
 			|| ($parsedTime['hour'] !== false && (int) $parsedTime['hour'] !== (int) $dateTime->format(self::TIME_OF_DAY))
 			|| ($parsedTime['minute'] !== false && (int) $parsedTime['minute'] !== (int) $dateTime->format(self::MINUTE_OF_HOUR_LEADING_ZERO))
 			|| ($parsedTime['second'] !== false && (int) $parsedTime['second'] !== (int) $dateTime->format(self::SECOND_OF_MINUTE_LEADING_ZERO))
+			|| ($parsedTime['fraction'] !== false && (float) $parsedTime['fraction'] !== (float) $dateTime->format('0.' . self::MICROSECOND_OF_SECOND))
 		) {
 			throw new \Consistence\Time\TimeDoesNotExistException($timeString);
 		}

--- a/src/Time/TimeFormat.php
+++ b/src/Time/TimeFormat.php
@@ -19,6 +19,7 @@ class TimeFormat extends \Consistence\ObjectPrototype
 	const ATOM = DATE_ATOM;
 	const COOKIE = DATE_COOKIE;
 	const ISO8601 = DATE_ISO8601;
+	const ISO8601_WITH_MICROSECONDS_WITHOUT_TIMEZONE = 'Y-m-d\TH:i:s.u';
 	const ISO8601_TIMEZONE_WITH_COLON = DATE_RFC3339;
 	const ISO8601_WITHOUT_TIMEZONE = 'Y-m-d\TH:i:s';
 	const RFC822 = DATE_RFC822;
@@ -101,7 +102,7 @@ class TimeFormat extends \Consistence\ObjectPrototype
 	 */
 	public static function createDateTimeFromDateTimeInterface(DateTimeInterface $date)
 	{
-		return new DateTime($date->format(self::ISO8601_WITHOUT_TIMEZONE), $date->getTimezone());
+		return new DateTime($date->format(self::ISO8601_WITH_MICROSECONDS_WITHOUT_TIMEZONE), $date->getTimezone());
 	}
 
 	/**
@@ -112,7 +113,7 @@ class TimeFormat extends \Consistence\ObjectPrototype
 	 */
 	public static function createDateTimeImmutableFromDateTimeInterface(DateTimeInterface $date)
 	{
-		return new DateTimeImmutable($date->format(self::ISO8601_WITHOUT_TIMEZONE), $date->getTimezone());
+		return new DateTimeImmutable($date->format(self::ISO8601_WITH_MICROSECONDS_WITHOUT_TIMEZONE), $date->getTimezone());
 	}
 
 	/**

--- a/tests/Time/TimeFormatTest.php
+++ b/tests/Time/TimeFormatTest.php
@@ -59,6 +59,10 @@ class TimeFormatTest extends \Consistence\TestCase
 			['Y-m-d H:i:s e', '2016-03-21 14:30:00 Europe/Prague'],
 			['Y-m-d H:i:s T', '2016-03-21 14:30:00 CEST'],
 			[TimeFormat::ISO8601, '2016-03-21T14:30:32-0100'],
+			[TimeFormat::ISO8601_WITH_MICROSECONDS, '2016-03-21T14:30:32.000001+0100'],
+			[TimeFormat::ISO8601_WITH_MICROSECONDS, '2016-03-21T14:30:32.100000+0100'],
+			[TimeFormat::ISO8601_WITH_MICROSECONDS, '2016-03-21T14:30:32.123456+0100'],
+			[TimeFormat::ISO8601_WITH_MICROSECONDS, '2016-03-21T14:30:32.999999+0100'],
 		];
 	}
 
@@ -73,6 +77,8 @@ class TimeFormatTest extends \Consistence\TestCase
 			['H:i', '2:30', 'missing leading zero in hour'],
 			['Y-m-d', '2016-1-2', 'there are missing zeroes at the beginning of day and month'],
 			[TimeFormat::ISO8601_TIMEZONE_WITH_COLON, '2016-03-21T14:30:32+0100', '`:` is required as timezone hour:minute separator'],
+			['s.u', '25.2', 'microseconds must have 6 digits'],
+			['s.u', '25.1234567', 'microseconds must have 6 digits'],
 		];
 	}
 

--- a/tests/Time/TimeFormatTest.php
+++ b/tests/Time/TimeFormatTest.php
@@ -30,7 +30,7 @@ class TimeFormatTest extends \Consistence\TestCase
 		$original = new DateTimeImmutable();
 		$converted = TimeFormat::createDateTimeFromDateTimeInterface($original);
 		$this->assertInstanceOf(DateTime::class, $converted);
-		$this->assertSame($original->getTimestamp(), $converted->getTimestamp());
+		$this->assertEquals($original, $converted);
 		$this->assertEquals($original->getTimezone(), $converted->getTimezone());
 	}
 
@@ -39,7 +39,7 @@ class TimeFormatTest extends \Consistence\TestCase
 		$original = new DateTime();
 		$converted = TimeFormat::createDateTimeImmutableFromDateTimeInterface($original);
 		$this->assertInstanceOf(DateTimeImmutable::class, $converted);
-		$this->assertSame($original->getTimestamp(), $converted->getTimestamp());
+		$this->assertEquals($original, $converted);
 		$this->assertEquals($original->getTimezone(), $converted->getTimezone());
 	}
 


### PR DESCRIPTION
PHP 7.1 introduced a [BC break](http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds) (marked as fix) that new `DateTime(Immutable)` instances contain microseconds, this can break conversion comparisons etc.