### PR TITLE
ArrayType::uniqueValues with strict comparison

### DIFF
--- a/src/Type/ArrayType/ArrayType.php
+++ b/src/Type/ArrayType/ArrayType.php
@@ -398,4 +398,28 @@ class ArrayType extends \Consistence\ObjectPrototype
 		return $result;
 	}
 
+	/**
+	 * Returns new array with unique values using callback(valueA, valueB),
+	 * values are same if callback returns trueish value
+	 *
+	 * @param mixed[] $haystack
+	 * @param \Closure $callback
+	 * @return mixed[] new array with unique values
+	 */
+	public static function uniqueValuesByCallback(array $haystack, Closure $callback)
+	{
+		$result = [];
+		foreach ($haystack as $newKey => $newValue) {
+			foreach ($result as $existingValue) {
+				if ($callback($existingValue, $newValue)) {
+					continue 2; // skip to next $value
+				}
+			}
+
+			$result[$newKey] = $newValue;
+		}
+
+		return $result;
+	}
+
 }

--- a/src/Type/ArrayType/ArrayType.php
+++ b/src/Type/ArrayType/ArrayType.php
@@ -379,4 +379,23 @@ class ArrayType extends \Consistence\ObjectPrototype
 		return $modified;
 	}
 
+	/**
+	 * Mimics the behaviour of array_unique, but makes strict comparisons by default
+	 *
+	 * @param mixed[] $haystack
+	 * @param boolean $strict
+	 * @return mixed[] new array with unique values
+	 */
+	public static function uniqueValues(array $haystack, $strict = self::STRICT_TRUE)
+	{
+		$result = [];
+		foreach ($haystack as $key => $value) {
+			if (!self::inArray($result, $value, $strict)) {
+				$result[$key] = $value;
+			}
+		}
+
+		return $result;
+	}
+
 }

--- a/tests/Type/ArrayType/ArrayTypeTest.php
+++ b/tests/Type/ArrayType/ArrayTypeTest.php
@@ -2,6 +2,8 @@
 
 namespace Consistence\Type\ArrayType;
 
+use DateTimeImmutable;
+
 class ArrayTypeTest extends \Consistence\TestCase
 {
 
@@ -444,6 +446,64 @@ class ArrayTypeTest extends \Consistence\TestCase
 			5 => 'bar',
 		]));
 		$this->assertCount(3, $values);
+	}
+
+	public function testUniqueValuesStrict()
+	{
+		$values = ['1', 1];
+		$expected = ['1', 1];
+
+		$actual = ArrayType::uniqueValues($values);
+
+		$this->assertSame($expected, $actual);
+	}
+
+	public function testUniqueValuesStrictWithObjects()
+	{
+		$values = [
+			new DateTimeImmutable('2017-01-01T12:00:00.000000'),
+			new DateTimeImmutable('2017-01-01T12:00:00.000000'),
+		];
+
+		$actual = ArrayType::uniqueValues($values);
+
+		$this->assertSame($values, $actual);
+	}
+
+	public function testUniqueValuesNonStrictBehavesAsArrayUniqueWithRegularComparison()
+	{
+		$values = ['1', 1];
+
+		$actual = ArrayType::uniqueValues($values, ArrayType::STRICT_FALSE);
+
+		$this->assertContains(1, $actual);
+		$this->assertCount(1, $actual);
+	}
+
+	public function testUniqueValuesNonStrictWithObjects()
+	{
+		$values = [
+			new DateTimeImmutable('2017-01-01T12:00:00.000000'),
+			new DateTimeImmutable('2017-01-01T12:00:00.000000'),
+		];
+
+		$actual = ArrayType::uniqueValues($values, ArrayType::STRICT_FALSE);
+
+		$this->assertContains(new DateTimeImmutable('2017-01-01T12:00:00.000000'), $actual, '', false, false);
+		$this->assertCount(1, $actual);
+	}
+
+	public function testUniqueValuesKeepsKeys()
+	{
+		$values = [
+			'a' => 'green',
+			0 => 'red',
+			1 => 'blue',
+		];
+
+		$actual = ArrayType::uniqueValues($values);
+
+		$this->assertSame($values, $actual);
 	}
 
 }

--- a/tests/Type/ArrayType/ArrayTypeTest.php
+++ b/tests/Type/ArrayType/ArrayTypeTest.php
@@ -506,4 +506,56 @@ class ArrayTypeTest extends \Consistence\TestCase
 		$this->assertSame($values, $actual);
 	}
 
+	public function testUniqueValuesByCallbackWithStrictComparison()
+	{
+		$values = ['1', 1];
+
+		$actual = ArrayType::uniqueValuesByCallback($values, function ($a, $b) {
+			return $a === $b;
+		});
+
+		$this->assertSame($values, $actual);
+	}
+
+	public function testUniqueValuesByCallbackWithStrictComparisonWithObjects()
+	{
+		$values = [
+			new DateTimeImmutable('2017-01-01T12:00:00.000000'),
+			new DateTimeImmutable('2017-01-01T12:00:00.000000'),
+		];
+
+		$actual = ArrayType::uniqueValuesByCallback($values, function ($a, $b) {
+			return $a === $b;
+		});
+
+		$this->assertSame($values, $actual);
+	}
+
+	public function testUniqueValuesByCallbackWithNonStrictComparison()
+	{
+		$values = ['1', 1];
+
+		$actual = ArrayType::uniqueValuesByCallback($values, function ($a, $b) {
+			return $a == $b;
+		});
+
+		$this->assertContains(1, $actual);
+		$this->assertCount(1, $actual);
+	}
+
+	public function testUniqueValuesByCallbackWithNonStrictComparisonWithObjects()
+	{
+		$values = [
+			new DateTimeImmutable('2017-01-01T12:00:00.000000'),
+			new DateTimeImmutable('2017-01-01T12:00:00.000000'),
+		];
+
+		$actual = ArrayType::uniqueValuesByCallback($values, function ($a, $b) {
+			return $a == $b;
+		});
+
+		$this->assertContains(new DateTimeImmutable('2017-01-01T12:00:00.000000'), $actual, '', false, false);
+		$this->assertCount(1, $actual);
+	}
+
 }


### PR DESCRIPTION
By default `array_unique` converts values to string. 

When using `Enum` classes with `array_unique` you'll get `PHP Warning:  Uncaught Object of class Some\EnumType could not be converted to string` unless you specify optional `SORT_REGULAR` parameter. And even then filtering array `['1', 1]` will yield `['1']`. 

`ArrayType::unique` solves this by using strict comparison using `ArrayType::inArray`. 