### PR TITLE
ArrayType::unique with strict comparison

### DIFF
--- a/src/Type/ArrayType/ArrayType.php
+++ b/src/Type/ArrayType/ArrayType.php
@@ -379,4 +379,22 @@ class ArrayType extends \Consistence\ObjectPrototype
 		return $modified;
 	}
 
+	/**
+	 * Mimics the behaviour of array_unique, but makes strict comparisons by default
+	 *
+	 * @param array $array
+	 * @param boolean $strict
+	 * @return array returns the filtered array with unique values
+	 */
+	public static function unique(array $array, $strict = self::STRICT_TRUE)
+	{
+		$result = [];
+		foreach ($array as $key => $value) {
+			if (self::inArray($result, $value, $strict) === false) {
+				$result[$key] = $value;
+			}
+		}
+		return $result;
+	}
+
 }

--- a/tests/Type/ArrayType/ArrayTypeTest.php
+++ b/tests/Type/ArrayType/ArrayTypeTest.php
@@ -446,4 +446,34 @@ class ArrayTypeTest extends \Consistence\TestCase
 		$this->assertCount(3, $values);
 	}
 
+	public function testUniqueStrict()
+	{
+		$values = ['1', 1];
+		$expected = ['1', 1];
+		$actual = ArrayType::unique($values);
+		$this->assertSame($expected, $actual);
+	}
+
+	public function testUniqueNonStrictBehavesAsArrayUniqueWithRegularComparison()
+	{
+		$values = ['1', 1];
+		$expected = array_unique($values, SORT_REGULAR);
+		$actual = ArrayType::unique($values, ArrayType::STRICT_FALSE);
+		$this->assertSame($expected, $actual);
+	}
+
+	public function testUniqueNonStrictKeepsKeysAsArrayUniqueWould()
+	{
+		$values = [
+			'a' => 'green',
+			0 => 'red',
+			'b' => 'green',
+			1 => 'blue',
+			2 => 'red',
+		];
+		$expected = array_unique($values, SORT_REGULAR);
+		$actual = ArrayType::unique($values, ArrayType::STRICT_FALSE);
+		$this->assertSame($expected, $actual);
+	}
+
 }


### PR DESCRIPTION
By default `array_unique` converts values to string. 

When using `Enum` classes with `array_unique` you'll get `PHP Warning:  Uncaught Object of class Some\EnumType could not be converted to string` unless you specify optional `SORT_REGULAR` parameter. And even then filtering array `['1', 1]` will yield `['1']`. 

`ArrayType::unique` solves this by using strict comparison using `ArrayType::inArray`. 

Supersedes #7