### PR TITLE
Enum::getAvailableEnums() to get all available instances of Enum

### DIFF
--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -4,6 +4,7 @@ namespace Consistence\Enum;
 
 use Consistence\Reflection\ClassReflection;
 use Consistence\Type\ArrayType\ArrayType;
+use Consistence\Type\ArrayType\KeyValuePair;
 use Consistence\Type\Type;
 
 use ReflectionClass;
@@ -66,6 +67,17 @@ abstract class Enum extends \Consistence\ObjectPrototype
 		}
 
 		return self::$availableValues[$index];
+	}
+
+	/**
+	 * @return static[] format: const name (string) => instance (static)
+	 */
+	public static function getAvailableEnums()
+	{
+		$values = static::getAvailableValues();
+		return ArrayType::mapByCallback($values, function (KeyValuePair $pair) {
+			return new KeyValuePair($pair->getKey(), static::get($pair->getValue()));
+		});
 	}
 
 	/**

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -74,6 +74,15 @@ class EnumTest extends \Consistence\TestCase
 		], StatusEnum::getAvailableValues());
 	}
 
+	public function testGetAvailableEnums()
+	{
+		$this->assertEquals([
+			'DRAFT' => StatusEnum::get(StatusEnum::DRAFT),
+			'REVIEW' => StatusEnum::get(StatusEnum::REVIEW),
+			'PUBLISHED' => StatusEnum::get(StatusEnum::PUBLISHED),
+		], StatusEnum::getAvailableEnums());
+	}
+
 	public function testIsValidValue()
 	{
 		$this->assertTrue(StatusEnum::isValidValue(StatusEnum::DRAFT));

--- a/tests/Enum/MultiEnumTest.php
+++ b/tests/Enum/MultiEnumTest.php
@@ -154,6 +154,15 @@ class MultiEnumTest extends \Consistence\TestCase
 		], RolesEnum::getAvailableValues());
 	}
 
+	public function testGetAvailableEnums()
+	{
+		$this->assertEquals([
+			'USER' => RolesEnum::get(RoleEnum::USER),
+			'EMPLOYEE' => RolesEnum::get(RoleEnum::EMPLOYEE),
+			'ADMIN' => RolesEnum::get(RoleEnum::ADMIN),
+		], RolesEnum::getAvailableEnums());
+	}
+
 	public function testGetNoValue()
 	{
 		$empty = RolesEnum::get(0);


### PR DESCRIPTION
This is a counterpart to `\Consistence\Enum\Enum::getAvailableValues()` which returns values, not actual Enum instances. 