### PR TITLE
Send coverage only for builds not allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ script:
   - bin/phing ci-build
 
 after_success:
-  - wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.0/coveralls.phar
-    && php coveralls.phar --verbose --config build/coveralls.yml
-    || true
+  - if [ "${TRAVIS_ALLOW_FAILURE}" = false ]; then
+        wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.0/coveralls.phar
+        && php coveralls.phar --verbose --config build/coveralls.yml
+        || true;
+    fi


### PR DESCRIPTION
Can fail because xdebug might not be updated etc.

https://coveralls.io/builds/11232043
https://coveralls.io/builds/11232043/source?filename=src%2FEnum%2Fexceptions%2FMultiEnumValueIsNotPowerOfTwoException.php
https://travis-ci.org/consistence/consistence/jobs/225628706#L344