### PR TITLE
Add containsKey and containsValue to make it consistent with findValue and findKey

### DIFF
--- a/docs/Enum/enums.md
+++ b/docs/Enum/enums.md
@@ -113,7 +113,7 @@ class CardSuit extends \Consistence\Enum\Enum
 	public function getCardColor()
 	{
 		return CardColor::get(
-			ArrayType::inArray($this->getValue(), self::$reds) ? CardColor::RED : CardColor::BLACK
+			ArrayType::containsValue($this->getValue(), self::$reds) ? CardColor::RED : CardColor::BLACK
 		);
 	}
 

--- a/docs/Enum/multi-enums.md
+++ b/docs/Enum/multi-enums.md
@@ -156,7 +156,7 @@ $allowedRoles = RolesEnum::getMulti(RolesEnum::USER);
 
 $userAndAdmin = RolesEnum::getMulti(RolesEnum::USER, RolesEnum::ADMIN);
 $user = $userAndAdmin->filterValues(function ($singleValue) use ($allowedRoles) {
-	return ArrayType::inArray($allowedRoles->getAvailableValues(), $singleValue);
+	return ArrayType::containsValue($allowedRoles->getAvailableValues(), $singleValue);
 });
 ```
 

--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -114,7 +114,7 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	 */
 	public static function isValidValue($value)
 	{
-		return ArrayType::inArray(static::getAvailableValues(), $value);
+		return ArrayType::containsValue(static::getAvailableValues(), $value);
 	}
 
 	/**

--- a/src/Type/ArrayType/ArrayType.php
+++ b/src/Type/ArrayType/ArrayType.php
@@ -16,6 +16,18 @@ class ArrayType extends \Consistence\ObjectPrototype
 	}
 
 	/**
+	 * Wrapper for array_key_exists
+	 *
+	 * @param mixed[] $haystack
+	 * @param integer|string $key
+	 * @return boolean
+	 */
+	public static function containsKey(array $haystack, $key)
+	{
+		return array_key_exists($key, $haystack);
+	}
+
+	/**
 	 * Wrapper for PHP in_array, provides safer default parameter
 	 *
 	 * @param mixed[] $haystack

--- a/src/Type/ArrayType/ArrayType.php
+++ b/src/Type/ArrayType/ArrayType.php
@@ -30,6 +30,8 @@ class ArrayType extends \Consistence\ObjectPrototype
 	/**
 	 * Wrapper for PHP in_array, provides safer default parameter
 	 *
+	 * @deprecated use self::containsValue() instead
+	 *
 	 * @param mixed[] $haystack
 	 * @param mixed $needle
 	 * @param boolean $strict
@@ -37,7 +39,34 @@ class ArrayType extends \Consistence\ObjectPrototype
 	 */
 	public static function inArray(array $haystack, $needle, $strict = self::STRICT_TRUE)
 	{
+		return self::containsValue($haystack, $needle, $strict);
+	}
+
+	/**
+	 * Wrapper for PHP in_array, provides safer default parameter
+	 *
+	 * @param mixed[] $haystack
+	 * @param mixed $needle
+	 * @param boolean $strict
+	 * @return boolean
+	 */
+	public static function containsValue(array $haystack, $needle, $strict = self::STRICT_TRUE)
+	{
 		return in_array($needle, $haystack, $strict);
+	}
+
+	/**
+	 * Returns true when callback(\Consistence\Type\ArrayType\KeyValuePair) is at least once trueish
+	 *
+	 * @deprecated use self::containsByCallback() instead
+	 *
+	 * @param mixed[] $haystack
+	 * @param \Closure $callback
+	 * @return boolean
+	 */
+	public static function inArrayByCallback(array $haystack, Closure $callback)
+	{
+		return self::containsByCallback($haystack, $callback);
 	}
 
 	/**
@@ -47,7 +76,7 @@ class ArrayType extends \Consistence\ObjectPrototype
 	 * @param \Closure $callback
 	 * @return boolean
 	 */
-	public static function inArrayByCallback(array $haystack, Closure $callback)
+	public static function containsByCallback(array $haystack, Closure $callback)
 	{
 		$result = self::findByCallback($haystack, $callback);
 		return $result !== null;
@@ -69,11 +98,25 @@ class ArrayType extends \Consistence\ObjectPrototype
 	/**
 	 * Returns true when callback(value) is at least once trueish
 	 *
+	 * @deprecated use self::containsValueByValueCallback() instead
+	 *
 	 * @param mixed[] $haystack
 	 * @param \Closure $callback
 	 * @return boolean
 	 */
 	public static function inArrayByValueCallback(array $haystack, Closure $callback)
+	{
+		return self::containsValueByValueCallback($haystack, $callback);
+	}
+
+	/**
+	 * Returns true when callback(value) is at least once trueish
+	 *
+	 * @param mixed[] $haystack
+	 * @param \Closure $callback
+	 * @return boolean
+	 */
+	public static function containsValueByValueCallback(array $haystack, Closure $callback)
 	{
 		$result = self::findValueByCallback($haystack, $callback);
 		return $result !== null;
@@ -415,7 +458,7 @@ class ArrayType extends \Consistence\ObjectPrototype
 	{
 		$result = [];
 		foreach ($haystack as $key => $value) {
-			if (!self::inArray($result, $value, $strict)) {
+			if (!self::containsValue($result, $value, $strict)) {
 				$result[$key] = $value;
 			}
 		}

--- a/src/Type/ArrayType/ArrayType.php
+++ b/src/Type/ArrayType/ArrayType.php
@@ -54,6 +54,19 @@ class ArrayType extends \Consistence\ObjectPrototype
 	}
 
 	/**
+	 * Returns true when callback(key) is at least once trueish
+	 *
+	 * @param mixed[] $haystack
+	 * @param \Closure $callback
+	 * @return boolean
+	 */
+	public static function containsKeyByValueCallback(array $haystack, Closure $callback)
+	{
+		$result = self::findKeyByValueCallback($haystack, $callback);
+		return $result !== null;
+	}
+
+	/**
 	 * Returns true when callback(value) is at least once trueish
 	 *
 	 * @param mixed[] $haystack

--- a/tests/Type/ArrayType/ArrayTypeTest.php
+++ b/tests/Type/ArrayType/ArrayTypeTest.php
@@ -7,6 +7,31 @@ use DateTimeImmutable;
 class ArrayTypeTest extends \Consistence\TestCase
 {
 
+	public function testContainsKeyIsNotStrict()
+	{
+		$values = [
+			'three' => 'three',
+			'7' => '7',
+			3 => 3,
+			null => null,
+			false => 'false',
+			true => 'true',
+			'nullValue' => null,
+		];
+
+		$this->assertTrue(ArrayType::containsKey($values, 'three'));
+		$this->assertTrue(ArrayType::containsKey($values, '7'));
+		$this->assertTrue(ArrayType::containsKey($values, 7));
+		$this->assertTrue(ArrayType::containsKey($values, null));
+		$this->assertTrue(ArrayType::containsKey($values, 3));
+		$this->assertTrue(ArrayType::containsKey($values, '3'));
+		$this->assertTrue(ArrayType::containsKey($values, '')); // null key
+		$this->assertTrue(ArrayType::containsKey($values, 0)); // false key
+		$this->assertTrue(ArrayType::containsKey($values, 1)); // true key
+		$this->assertTrue(ArrayType::containsKey($values, 'nullValue'));
+		$this->assertFalse(ArrayType::containsKey($values, '99'));
+	}
+
 	public function testStaticConstruct()
 	{
 		$this->expectException(\Consistence\StaticClassException::class);

--- a/tests/Type/ArrayType/ArrayTypeTest.php
+++ b/tests/Type/ArrayType/ArrayTypeTest.php
@@ -83,6 +83,22 @@ class ArrayTypeTest extends \Consistence\TestCase
 		}));
 	}
 
+	public function testContainsKeyByValueCallback()
+	{
+		$values = [1, 2, 3];
+		$this->assertTrue(ArrayType::containsKeyByValueCallback($values, function ($value) {
+			return ($value % 2) === 0;
+		}));
+	}
+
+	public function testContainsKeyByValueCallbackNotFound()
+	{
+		$values = [1, 2, 3];
+		$this->assertFalse(ArrayType::containsKeyByValueCallback($values, function ($value) {
+			return ($value % 5) === 0;
+		}));
+	}
+
 	public function testInArrayByValueCallback()
 	{
 		$values = [1, 2, 3];

--- a/tests/Type/ArrayType/ArrayTypeTest.php
+++ b/tests/Type/ArrayType/ArrayTypeTest.php
@@ -46,11 +46,25 @@ class ArrayTypeTest extends \Consistence\TestCase
 		$this->assertFalse(ArrayType::inArray($values, '2'));
 	}
 
+	public function testContainsValueDefault()
+	{
+		$values = [1, 2, 3];
+		$this->assertTrue(ArrayType::containsValue($values, 2));
+		$this->assertFalse(ArrayType::containsValue($values, '2'));
+	}
+
 	public function testInArrayStrict()
 	{
 		$values = [1, 2, 3];
 		$this->assertTrue(ArrayType::inArray($values, 2, ArrayType::STRICT_TRUE));
 		$this->assertFalse(ArrayType::inArray($values, '2', ArrayType::STRICT_TRUE));
+	}
+
+	public function testContainsValueStrict()
+	{
+		$values = [1, 2, 3];
+		$this->assertTrue(ArrayType::containsValue($values, 2, ArrayType::STRICT_TRUE));
+		$this->assertFalse(ArrayType::containsValue($values, '2', ArrayType::STRICT_TRUE));
 	}
 
 	public function testInArrayLoose()
@@ -59,10 +73,24 @@ class ArrayTypeTest extends \Consistence\TestCase
 		$this->assertTrue(ArrayType::inArray($values, '2', ArrayType::STRICT_FALSE));
 	}
 
+	public function testContainsValueLoose()
+	{
+		$values = [1, 2, 3];
+		$this->assertTrue(ArrayType::containsValue($values, '2', ArrayType::STRICT_FALSE));
+	}
+
 	public function testInArrayByCallback()
 	{
 		$values = [1, 2, 3];
 		$this->assertTrue(ArrayType::inArrayByCallback($values, function (KeyValuePair $pair) {
+			return ($pair->getValue() % 2) === 0;
+		}));
+	}
+
+	public function testContainsByCallback()
+	{
+		$values = [1, 2, 3];
+		$this->assertTrue(ArrayType::containsByCallback($values, function (KeyValuePair $pair) {
 			return ($pair->getValue() % 2) === 0;
 		}));
 	}
@@ -75,10 +103,26 @@ class ArrayTypeTest extends \Consistence\TestCase
 		}));
 	}
 
+	public function testContainsByCallbackLoose()
+	{
+		$values = [1, 2, 3];
+		$this->assertTrue(ArrayType::containsByCallback($values, function (KeyValuePair $pair) {
+			return $pair->getValue() == '2';
+		}));
+	}
+
 	public function testInArrayByCallbackNotFound()
 	{
 		$values = [1, 2, 3];
 		$this->assertFalse(ArrayType::inArrayByCallback($values, function (KeyValuePair $pair) {
+			return $pair->getValue() === 0;
+		}));
+	}
+
+	public function testContainsByCallbackNotFound()
+	{
+		$values = [1, 2, 3];
+		$this->assertFalse(ArrayType::containsByCallback($values, function (KeyValuePair $pair) {
 			return $pair->getValue() === 0;
 		}));
 	}
@@ -107,6 +151,14 @@ class ArrayTypeTest extends \Consistence\TestCase
 		}));
 	}
 
+	public function testContainsValueByValueCallback()
+	{
+		$values = [1, 2, 3];
+		$this->assertTrue(ArrayType::containsValueByValueCallback($values, function ($value) {
+			return ($value % 2) === 0;
+		}));
+	}
+
 	public function testInArrayByValueCallbackLoose()
 	{
 		$values = [1, 2, 3];
@@ -115,10 +167,26 @@ class ArrayTypeTest extends \Consistence\TestCase
 		}));
 	}
 
+	public function testContainsValueByValueCallbackLoose()
+	{
+		$values = [1, 2, 3];
+		$this->assertTrue(ArrayType::containsValueByValueCallback($values, function ($value) {
+			return $value == '2';
+		}));
+	}
+
 	public function testInArrayByValueCallbackNotFound()
 	{
 		$values = [1, 2, 3];
 		$this->assertFalse(ArrayType::inArrayByValueCallback($values, function ($value) {
+			return $value === 0;
+		}));
+	}
+
+	public function testContainsValueByValueCallbackNotFound()
+	{
+		$values = [1, 2, 3];
+		$this->assertFalse(ArrayType::containsValueByValueCallback($values, function ($value) {
 			return $value === 0;
 		}));
 	}


### PR DESCRIPTION
* added hasKey()
* added hasValue*()
* deprecated inArray*() and proxy to hasValue*()