### PR TITLE
Enable to create enum by magic static calls

### DIFF
--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -167,4 +167,13 @@ abstract class Enum extends \Consistence\ObjectPrototype
 		return $this->getValue() === $value;
 	}
 
+	public static function __callStatic($name, array $arguments)
+	{
+		if (!array_key_exists($name, self::getAvailableValues())) {
+			throw new \Consistence\Enum\InvalidEnumConstantException($name, static::class, array_keys(self::getAvailableValues()));
+		};
+
+		return self::get(constant('static::' . $name));
+	}
+
 }

--- a/src/Enum/exceptions/InvalidEnumConstantException.php
+++ b/src/Enum/exceptions/InvalidEnumConstantException.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Enum;
+
+class InvalidEnumConstantException extends \Consistence\PhpException
+{
+
+	/** @var mixed */
+	private $value;
+
+	/** @var string */
+	private $class;
+
+	/** @var mixed[] */
+	private $availableValues;
+
+	/**
+	 * @param mixed $value
+	 * @param string $class
+	 * @param array $availableConstants
+	 * @param \Throwable|null $previous
+	 */
+	public function __construct($value, string $class, array $availableConstants, \Throwable $previous = null)
+	{
+		parent::__construct(sprintf(
+			'%s is not a valid constant name of class %s, accepted values: %s',
+			$value,
+			$class,
+			implode(', ', $availableConstants)
+		), $previous);
+		$this->value = $value;
+		$this->class = $class;
+		$this->availableValues = $availableConstants;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+	public function getClass(): string
+	{
+		return $this->class;
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function getAvailableValues(): array
+	{
+		return $this->availableValues;
+	}
+
+}

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -201,4 +201,22 @@ class EnumTest extends \Consistence\TestCase
 		}
 	}
 
+	public function testMagicGet()
+	{
+		$role = RoleEnum::ADMIN();
+		$this->assertSame($role, RoleEnum::get(RoleEnum::ADMIN));
+	}
+
+	public function testMagicGetThrowsException()
+	{
+		try {
+			RoleEnum::NON_EXISTING_ROLE();
+		} catch (\Consistence\Enum\InvalidEnumConstantException $e) {
+			$this->assertSame('NON_EXISTING_ROLE is not a valid constant name of class Consistence\Enum\RoleEnum, accepted values: USER, EMPLOYEE, ADMIN', $e->getMessage());
+			$this->assertSame('NON_EXISTING_ROLE', $e->getValue());
+			$this->assertSame('Consistence\Enum\RoleEnum', $e->getClass());
+			$this->assertEquals(array_keys(RoleEnum::getAvailableValues()), $e->getAvailableValues());
+		}
+	}
+
 }


### PR DESCRIPTION
Enable to call RoleEnum::ADMIN() instead of RoleEnum::get(RoleEnum::ADMIN)