### PR TITLE
Added ability to do Enum::CONST_NAME()

### DIFF
--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -19,6 +19,9 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	/** @var self[] indexed by enum and value */
 	private static $instances = [];
 
+	/** @var indexed by enum and name */
+	private static $valueByName = [];
+
 	/** @var mixed[] format: enum name (string) => cached values (const name (string) => value (mixed)) */
 	private static $availableValues;
 
@@ -30,6 +33,29 @@ abstract class Enum extends \Consistence\ObjectPrototype
 		static::checkValue($value);
 		$this->value = $value;
 	}
+
+	/**
+	 * Supports `Enum::CONST_NAME()`.
+	 * @param string $name An existing constant name
+	 */
+    public static final function __callStatic($name, array $args)
+    {
+        return static::getByname($name);
+    }
+
+    /**
+     * Retrieves an instance of the enum from the constant's name.
+     */
+    public static final function getByName($name)
+    {
+        $nameMap = static::getAvailableEnums();
+
+        if (!isset($nameMap[$name])) {
+            throw new \Consistence\Enum\InvalidEnumValueException("name:$name", static::getAvailableValues());
+        }
+
+        return $nameMap[$name];
+    }
 
 	/**
 	 * @param mixed $value

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -201,4 +201,8 @@ class EnumTest extends \Consistence\TestCase
 		}
 	}
 
+	public function testGetByName()
+	{
+		$this->assertSame(StatusEnum::DRAFT(), StatusEnum::get(1));
+	}
 }


### PR DESCRIPTION
i thought it was a bit cumbersome to do `Enum::get(Enum::CONST_NAME)` -- too much work when you already know the constant you want to reference.

instead, i should be able to do `Enum::CONST_NAME()`. it's more concise and makes enums similar to java enums.