### PR TITLE
Implement JsonSerializable in Enum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
 		}
 	],
 	"require": {
-		"php": "~7.0"
+		"php": "~7.0",
+		"ext-json": "*"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "2.2.1",

--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -10,7 +10,7 @@ use Consistence\Type\ArrayType\KeyValuePair;
 use Consistence\Type\Type;
 use ReflectionClass;
 
-abstract class Enum extends \Consistence\ObjectPrototype
+abstract class Enum extends \Consistence\ObjectPrototype implements \JsonSerializable
 {
 
 	/** @var mixed */
@@ -165,6 +165,14 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	public function equalsValue($value): bool
 	{
 		return $this->getValue() === $value;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function jsonSerialize()
+	{
+		return $this->getValue();
 	}
 
 }

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -5,6 +5,9 @@ declare(strict_types = 1);
 namespace Consistence\Enum;
 
 use Consistence\Type\ArrayType\ArrayType;
+use const JSON_PRESERVE_ZERO_FRACTION;
+use function json_decode;
+use function json_encode;
 
 class EnumTest extends \Consistence\TestCase
 {
@@ -199,6 +202,20 @@ class EnumTest extends \Consistence\TestCase
 			$this->assertSame(DuplicateValuesEnum::FOO, $e->getValue());
 			$this->assertSame(DuplicateValuesEnum::class, $e->getClass());
 		}
+	}
+
+	/**
+	 * @dataProvider typesProvider
+	 *
+	 * @param mixed $value
+	 */
+	public function testJsonSerialize($value)
+	{
+		$enum = TypeEnum::get($value);
+		$serialized = json_encode($enum, JSON_PRESERVE_ZERO_FRACTION);
+		$deserialized = TypeEnum::get(json_decode($serialized));
+
+		$this->assertSame($enum, $deserialized);
 	}
 
 }


### PR DESCRIPTION
It's quite annoying to `->getValue()` on all the enums while trying to serialize more complex structures...

ext-json is pretty much a standard lib, it shouldn't hurt to require it.