### PR TITLE
Include class name in message for InvalidEnumValueException

### DIFF
--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -124,7 +124,7 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	public static function checkValue($value)
 	{
 		if (!static::isValidValue($value)) {
-			throw new \Consistence\Enum\InvalidEnumValueException($value, static::getAvailableValues());
+			throw new \Consistence\Enum\InvalidEnumValueException($value, static::class);
 		}
 	}
 

--- a/src/Enum/MultiEnum.php
+++ b/src/Enum/MultiEnum.php
@@ -176,13 +176,13 @@ abstract class MultiEnum extends \Consistence\Enum\Enum implements \IteratorAggr
 	{
 		Type::checkType($value, 'int');
 		if ($value < 0) {
-			throw new \Consistence\Enum\InvalidEnumValueException($value, self::getAvailableValues());
+			throw new \Consistence\Enum\InvalidEnumValueException($value, static::class);
 		}
 		$check = 1;
 		while ($check <= $value) {
 			if ($value & $check) {
 				if (!static::isValidValue($check)) {
-					throw new \Consistence\Enum\InvalidEnumValueException($check, self::getAvailableValues());
+					throw new \Consistence\Enum\InvalidEnumValueException($check, static::class);
 				}
 			}
 			$check <<= 1;

--- a/src/Enum/exceptions/InvalidEnumValueException.php
+++ b/src/Enum/exceptions/InvalidEnumValueException.php
@@ -15,21 +15,40 @@ class InvalidEnumValueException extends \Consistence\PhpException
 	/** @var mixed[] */
 	private $availableValues;
 
+	/** @var string */
+	private $enumClassName;
+
 	/**
 	 * @param mixed $value
-	 * @param mixed[] $availableValues
+	 * @param string $enumClassName
 	 * @param \Throwable|null $previous
 	 */
-	public function __construct($value, array $availableValues, \Throwable $previous = null)
+	public function __construct($value, string $enumClassName, \Throwable $previous = null)
 	{
+		if (!is_subclass_of($enumClassName, Enum::class)) {
+			// @codeCoverageIgnoreStart
+			// cannot be tested because it throws general exception
+			throw new \Exception(sprintf(
+				'"%s" is not a subclass of "%s"',
+				$enumClassName,
+				Enum::class
+			));
+			// @codeCoverageIgnoreEnd
+		}
+
+		$availableValues = $enumClassName::getAvailableValues();
+
 		parent::__construct(sprintf(
-			'%s [%s] is not a valid value, accepted values: %s',
+			'%s [%s] is not a valid value for %s, accepted values: %s',
 			$value,
 			Type::getType($value),
+			$enumClassName,
 			implode(', ', $availableValues)
 		), $previous);
+
 		$this->value = $value;
 		$this->availableValues = $availableValues;
+		$this->enumClassName = $enumClassName;
 	}
 
 	/**
@@ -46,6 +65,11 @@ class InvalidEnumValueException extends \Consistence\PhpException
 	public function getAvailableValues(): array
 	{
 		return $this->availableValues;
+	}
+
+	public function getEnumClassName(): string
+	{
+		return $this->enumClassName;
 	}
 
 }

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -107,6 +107,7 @@ class EnumTest extends \Consistence\TestCase
 				'REVIEW' => StatusEnum::REVIEW,
 				'PUBLISHED' => StatusEnum::PUBLISHED,
 			], $e->getAvailableValues());
+			$this->assertSame(StatusEnum::class, $e->getEnumClassName());
 		}
 	}
 
@@ -129,6 +130,7 @@ class EnumTest extends \Consistence\TestCase
 				'REVIEW' => StatusEnum::REVIEW,
 				'PUBLISHED' => StatusEnum::PUBLISHED,
 			], $e->getAvailableValues());
+			$this->assertSame(StatusEnum::class, $e->getEnumClassName());
 		}
 	}
 

--- a/tests/Enum/MultiEnumTest.php
+++ b/tests/Enum/MultiEnumTest.php
@@ -231,6 +231,7 @@ class MultiEnumTest extends \Consistence\TestCase
 				'EMPLOYEE' => RoleEnum::EMPLOYEE,
 				'ADMIN' => RoleEnum::ADMIN,
 			], $e->getAvailableValues());
+			$this->assertSame(RolesEnum::class, $e->getEnumClassName());
 		}
 	}
 


### PR DESCRIPTION
The `InvalidEnumValueException` is thrown from the `Enum` or `MultiEnum` class so the actual class name is not included in stack trace:

```
8 [int] is not a valid value, accepted values: 1, 2, 4
 C:\dev\htdocs\consistence\consistence\src\Enum\MultiEnum.php:185
 C:\dev\htdocs\consistence\consistence\src\Enum\Enum.php:30
 C:\dev\htdocs\consistence\consistence\src\Enum\Enum.php:42
 C:\dev\htdocs\consistence\consistence\tests\Enum\MultiEnumTest.php:224
 ```

**This patch makes is easier to in which enum the value is missing.**

Before:
```
"foo [string] is not a valid value, accepted values: 1, 2, 3"
"8 [int] is not a valid value, accepted values: 1, 2, 4"
```

After:
```
"foo [string] is not a valid value for Consistence\Enum\StatusEnum, accepted values: 1, 2, 3"
"8 [int] is not a valid value for Consistence\Enum\RolesEnum, accepted values: 1, 2, 4"
```