### PR TITLE
Remove reflection filters

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -12,8 +12,6 @@ use ReflectionProperty;
 class ClassReflection extends \Consistence\ObjectPrototype
 {
 
-	public const FILTER_VISIBILITY_NONE = -1;
-
 	public const CASE_SENSITIVE = true;
 	public const CASE_INSENSITIVE = false;
 
@@ -26,12 +24,11 @@ class ClassReflection extends \Consistence\ObjectPrototype
 	 * Retrieves methods defined only at the same level as given ReflectionClass
 	 *
 	 * @param \ReflectionClass $classReflection
-	 * @param int $filter
 	 * @return \ReflectionMethod[]
 	 */
-	public static function getDeclaredMethods(ReflectionClass $classReflection, int $filter = self::FILTER_VISIBILITY_NONE): array
+	public static function getDeclaredMethods(ReflectionClass $classReflection): array
 	{
-		$methods = $classReflection->getMethods($filter);
+		$methods = $classReflection->getMethods();
 		$className = $classReflection->getName();
 		return ArrayType::filterValuesByCallback($methods, function (ReflectionMethod $method) use ($className): bool {
 			return $method->class === $className;
@@ -65,12 +62,11 @@ class ClassReflection extends \Consistence\ObjectPrototype
 	 * Retrieves properties defined only at the same level as given ReflectionClass
 	 *
 	 * @param \ReflectionClass $classReflection
-	 * @param int $filter
 	 * @return \ReflectionProperty[]
 	 */
-	public static function getDeclaredProperties(ReflectionClass $classReflection, int $filter = self::FILTER_VISIBILITY_NONE): array
+	public static function getDeclaredProperties(ReflectionClass $classReflection): array
 	{
-		$properties = $classReflection->getProperties($filter);
+		$properties = $classReflection->getProperties();
 		$className = $classReflection->getName();
 		return ArrayType::filterValuesByCallback($properties, function (ReflectionProperty $property) use ($className): bool {
 			return $property->class === $className;


### PR DESCRIPTION
Since their behavior is not obvious and can be better replaced by result filtering by dedicated methods.

See http://php.net/manual/en/reflectionclass.getmethods.php for example:

> Any bitwise disjunction of ReflectionMethod::IS_STATIC, ReflectionMethod::IS_PUBLIC, ReflectionMethod::IS_PROTECTED, ReflectionMethod::IS_PRIVATE, ReflectionMethod::IS_ABSTRACT, ReflectionMethod::IS_FINAL, so that all methods with any of the given attributes will be returned. 

> Note that other bitwise operations, for instance ~ will not work as expected. In other words, it is not possible to retrieve all non-static methods, for example.

Using `isPrivate()`/`isPublic()`/`isProtected()`/`isStatic()` on reflection collection result is recommended instead. For example this solves the situation mentioned before:

```php
$classReflection = new ReflectionClass(Foo::class);
ArrayType::filterValuesByCallback(
	ClassReflection::getDeclaredMethods($classReflection),
	function (ReflectionMethod $method): bool {
		return !$method->isStatic();
	}
);
```