### PR TITLE
Return reflection classes from ClassReflection::getDeclaredConstants()

### DIFF
--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -9,6 +9,7 @@ use Consistence\Type\ArrayType\ArrayType;
 use Consistence\Type\ArrayType\KeyValuePair;
 use Consistence\Type\Type;
 use ReflectionClass;
+use ReflectionClassConstant;
 
 abstract class Enum extends \Consistence\ObjectPrototype
 {
@@ -87,7 +88,18 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	private static function getEnumConstants(): array
 	{
 		$classReflection = new ReflectionClass(get_called_class());
-		$declaredConstants = ClassReflection::getDeclaredConstants($classReflection);
+		$declaredConstants = ArrayType::mapByCallback(
+			ClassReflection::getDeclaredConstants($classReflection),
+			function (KeyValuePair $keyValuePair): KeyValuePair {
+				$constant = $keyValuePair->getValue();
+				assert($constant instanceof ReflectionClassConstant);
+
+				return new KeyValuePair(
+					$constant->getName(),
+					$constant->getValue()
+				);
+			}
+		);
 		ArrayType::removeKeys($declaredConstants, static::getIgnoredConstantNames());
 
 		return $declaredConstants;

--- a/tests/Reflection/ClassReflectionTest.php
+++ b/tests/Reflection/ClassReflectionTest.php
@@ -71,7 +71,7 @@ class ClassReflectionTest extends \Consistence\TestCase
 		$classReflection = new ReflectionClass(Bar::class);
 		$constants = ClassReflection::getDeclaredConstants($classReflection);
 		$this->assertCount(1, $constants);
-		$this->assertArrayHasKey('BAR', $constants);
+		$this->assertSame('BAR', $constants[0]->name);
 	}
 
 	public function testHasDeclaredConstant(): void


### PR DESCRIPTION
* this unifies the interface with other methods on `ClassReflection`
* reflection classes were not originally available when `ClassReflection` was created

If you need to keep using it the same way, you can use something like the example below:

```php
ArrayType::mapByCallback(
	ClassReflection::getDeclaredConstants($classReflection),
	function (KeyValuePair $keyValuePair): KeyValuePair {
		$constant = $keyValuePair->getValue();
		assert($constant instanceof ReflectionClassConstant);
		return new KeyValuePair(
			$constant->getName(),
			$constant->getValue()
		);
	}
);
```