### PR TITLE
Use only public constants as default available values in Enum instead of using getIgnoredConstantNames()

### DIFF
--- a/docs/Enum/enums.md
+++ b/docs/Enum/enums.md
@@ -102,7 +102,7 @@ class CardSuit extends \Consistence\Enum\Enum
 	public const HEARTS = 'hearts';
 	public const SPADES = 'spades';
 
-	private static $reds = [
+	private const REDS = [
 		self::DIAMONDS,
 		self::HEARTS,
 	];
@@ -110,7 +110,7 @@ class CardSuit extends \Consistence\Enum\Enum
 	public function getCardColor(): CardColor
 	{
 		return CardColor::get(
-			ArrayType::containsValue($this->getValue(), self::$reds) ? CardColor::RED : CardColor::BLACK
+			ArrayType::containsValue($this->getValue(), self::REDS) ? CardColor::RED : CardColor::BLACK
 		);
 	}
 
@@ -138,9 +138,9 @@ function doMagicTrick(CardSuit $guessedCardSuit)
 Ignored constant values
 -----------------------
 
-By default, values are read from constants defined on the enum class as shown in the `CardColor` and `CardSuit` examples above.
+By default, values are read from public constants defined on the enum class as shown in the `CardColor` and `CardSuit` examples above.
 
-If you want to exclude some constants from being values (for example because they are needed for implementation of methods), you only need to list them in `getIgnoredConstantNames`:
+If you define a constant as private or protected, they will not be available as values:
 
 ```php
 <?php
@@ -153,15 +153,12 @@ class CardSuit extends \Consistence\Enum\Enum
 	public const HEARTS = 'hearts';
 	public const SPADES = 'spades';
 
-	public const SYMBOL_CLUBS = '♣';
-	public const SYMBOL_DIAMONDS = '♦';
-	public const SYMBOL_HEARTS = '♥';
-	public const SYMBOL_SPADES = '♠';
+	private const SYMBOL_CLUBS = '♣';
+	private const SYMBOL_DIAMONDS = '♦';
+	private const SYMBOL_HEARTS = '♥';
+	private const SYMBOL_SPADES = '♠';
 
-	/**
-	 * @var string[] format: value(string) => symbol(string)
-	 */
-	private static $symbolMap = [
+	private const SYMBOL_MAP = [
 		self::CLUBS => self::SYMBOL_CLUBS,
 		self::DIAMONDS => self::SYMBOL_DIAMONDS,
 		self::HEARTS => self::SYMBOL_HEARTS,
@@ -170,31 +167,20 @@ class CardSuit extends \Consistence\Enum\Enum
 
 	public function getSymbol(): string
 	{
-		if (!isset(self::$symbolMap[$this->getValue()])) {
-			throw new \Exception('Undefinded symbol');
+		if (!isset(self::SYMBOL_MAP[$this->getValue()])) {
+			throw new \Exception('Undefined symbol');
 		}
 
-		return self::$symbolMap[$this->getValue()];
-	}
-
-	/**
-	 * @return string[] names of constants which should not be used as valid values of this enum
-	 */
-	protected static function getIgnoredConstantNames()
-	{
-		return [
-			'SYMBOL_CLUBS',
-			'SYMBOL_DIAMONDS',
-			'SYMBOL_HEARTS',
-			'SYMBOL_SPADES',
-		];
+		return self::SYMBOL_MAP[$this->getValue()];
 	}
 
 }
 
 // Consistence\Enum\InvalidEnumValueException: ♣ [string] is not a valid value, accepted values: clubs, diamonds, hearts, spades
-CardSuit::get(CardSuit::SYMBOL_CLUBS);
+CardSuit::get('♣');
 ```
+
+If you need to exclude some public variables, you can do so on by overriding `getAvailableValues` (see next chapter).
 
 Custom definition of values
 ---------------------------

--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -88,8 +88,16 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	private static function getEnumConstants(): array
 	{
 		$classReflection = new ReflectionClass(get_called_class());
-		$declaredConstants = ArrayType::mapByCallback(
-			ClassReflection::getDeclaredConstants($classReflection),
+		$declaredConstants = ClassReflection::getDeclaredConstants($classReflection);
+		$declaredPublicConstants = ArrayType::filterValuesByCallback(
+			$declaredConstants,
+			function (ReflectionClassConstant $constant): bool {
+				return $constant->isPublic();
+			}
+		);
+
+		return ArrayType::mapByCallback(
+			$declaredPublicConstants,
 			function (KeyValuePair $keyValuePair): KeyValuePair {
 				$constant = $keyValuePair->getValue();
 				assert($constant instanceof ReflectionClassConstant);
@@ -100,9 +108,6 @@ abstract class Enum extends \Consistence\ObjectPrototype
 				);
 			}
 		);
-		ArrayType::removeKeys($declaredConstants, static::getIgnoredConstantNames());
-
-		return $declaredConstants;
 	}
 
 	/**
@@ -138,14 +143,6 @@ abstract class Enum extends \Consistence\ObjectPrototype
 		if (!static::isValidValue($value)) {
 			throw new \Consistence\Enum\InvalidEnumValueException($value, static::class);
 		}
-	}
-
-	/**
-	 * @return string[] names of constants which should not be used as valid values of this enum
-	 */
-	protected static function getIgnoredConstantNames(): iterable
-	{
-		return [];
 	}
 
 	protected function checkSameEnum(self $that): void

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -158,10 +158,10 @@ class EnumTest extends \Consistence\TestCase
 	public function testIgnoredConstant(): void
 	{
 		try {
-			StatusEnum::get(StatusEnum::BAR);
+			StatusEnum::get('bar');
 			$this->fail();
 		} catch (\Consistence\Enum\InvalidEnumValueException $e) {
-			$this->assertSame(StatusEnum::BAR, $e->getValue());
+			$this->assertSame('bar', $e->getValue());
 			$this->assertEquals([
 				'DRAFT' => StatusEnum::DRAFT,
 				'REVIEW' => StatusEnum::REVIEW,

--- a/tests/Enum/data/StatusEnum.php
+++ b/tests/Enum/data/StatusEnum.php
@@ -11,16 +11,6 @@ class StatusEnum extends \Consistence\Enum\Enum
 	public const REVIEW = 2;
 	public const PUBLISHED = 3;
 
-	public const BAR = 'yy';
-
-	/**
-	 * @return string[]
-	 */
-	protected static function getIgnoredConstantNames(): array
-	{
-		return [
-			'BAR',
-		];
-	}
+	private const BAR = 'bar';
 
 }


### PR DESCRIPTION
* using only public constants is expected behavior (but when Enums were created there was no constant visibility)
* using `getIgnoredConstantNames()` can be non-obvious, since it can be ignored as soon as you override `getAvailableValues()`

In your classes remove the `getIgnoredConstantNames()` and declare the contants as private. Or if they need to stay public, then filter them out by overriding `getAvailableValues()`, for example like this:

```php
public static function getAvailableValues(): iterable
{
	$constants = parent::getAvailableValues();
	ArrayType::removeKeys($constants, [
		'IGNORE_ME',
	]);

	return $constants;
}
```