### PR TITLE
Remove deprecated ArrayType::containsKeyByValueCallback()

### DIFF
--- a/src/Type/ArrayType/ArrayType.php
+++ b/src/Type/ArrayType/ArrayType.php
@@ -58,20 +58,6 @@ class ArrayType extends \Consistence\ObjectPrototype
 	/**
 	 * Returns true when callback(value) is at least once trueish
 	 *
-	 * @deprecated behaves the same way as containsValueByValueCallback, since both use value callback
-	 *
-	 * @param mixed[] $haystack
-	 * @param \Closure $callback
-	 * @return bool
-	 */
-	public static function containsKeyByValueCallback(array $haystack, Closure $callback): bool
-	{
-		return self::containsValueByValueCallback($haystack, $callback);
-	}
-
-	/**
-	 * Returns true when callback(value) is at least once trueish
-	 *
 	 * @param mixed[] $haystack
 	 * @param \Closure $callback
 	 * @return bool

--- a/tests/Type/ArrayType/ArrayTypeTest.php
+++ b/tests/Type/ArrayType/ArrayTypeTest.php
@@ -91,22 +91,6 @@ class ArrayTypeTest extends \Consistence\TestCase
 		}));
 	}
 
-	public function testContainsKeyByValueCallback(): void
-	{
-		$values = [1, 2, 3];
-		$this->assertTrue(ArrayType::containsKeyByValueCallback($values, function (int $value): bool {
-			return ($value % 2) === 0;
-		}));
-	}
-
-	public function testContainsKeyByValueCallbackNotFound(): void
-	{
-		$values = [1, 2, 3];
-		$this->assertFalse(ArrayType::containsKeyByValueCallback($values, function (int $value): bool {
-			return ($value % 5) === 0;
-		}));
-	}
-
 	public function testContainsValueByValueCallback(): void
 	{
 		$values = [1, 2, 3];


### PR DESCRIPTION
Use `ArrayType::containsValueByValueCallback()` which behaves the same.