### PR TITLE
Fix Enum::equals() for unserialized enums

### DIFF
--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -164,7 +164,7 @@ abstract class Enum extends \Consistence\ObjectPrototype
 	{
 		$this->checkSameEnum($that);
 
-		return $this === $that;
+		return $this->equalsValue($that->getValue());
 	}
 
 	/**

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -41,8 +41,10 @@ class EnumTest extends \Consistence\TestCase
 	{
 		$review1 = StatusEnum::get(StatusEnum::REVIEW);
 		$review2 = StatusEnum::get(StatusEnum::REVIEW);
+		$review3 = unserialize(serialize($review1));
 
 		$this->assertTrue($review1->equals($review2));
+		$this->assertTrue($review1->equals($review3));
 	}
 
 	public function testNotEquals(): void


### PR DESCRIPTION
`Enum::equals()` currently uses direct comparison of enum instances to resolve equality. This is problematic once you try to use unserialized instance of enums.